### PR TITLE
fix: Color.ToString now returns the expected format

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI/Given_Color.cs
+++ b/src/Uno.UI.Tests/Windows_UI/Given_Color.cs
@@ -1,0 +1,17 @@
+﻿using Windows.UI;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Uno.UI.Tests.Windows_UI
+{
+	[TestClass]
+	public class Given_Color
+	{
+		[TestMethod]
+		public void When_UsingToString()
+		{
+			var color = new Color() { A = 255, R = 0, G = 128, B = 255 };
+
+			Assert.AreEqual("#FF0080FF", color.ToString());
+		}
+	}
+}

--- a/src/Uno.UWP/UI/Color.cs
+++ b/src/Uno.UWP/UI/Color.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 
 namespace Windows.UI
 {
@@ -34,9 +35,19 @@ namespace Windows.UI
 
 		public override int GetHashCode() => (A << 8) ^ (R << 6) ^ (G << 4) ^ B;
 
-		public override string ToString() => $"[#{A:X2}{R:X2}{G:X2}{B:X2}]";
+		public override string ToString() => ToString(null, null);
 
-		public string ToString(string format, IFormatProvider provider) => ToString();
+		public string ToString(string format, IFormatProvider provider)
+		{
+			var sb = new StringBuilder();
+
+			sb.AppendFormat(provider, "#{0:X2}", A);
+			sb.AppendFormat(provider, "{0:X2}", R);
+			sb.AppendFormat(provider, "{0:X2}", G);
+			sb.AppendFormat(provider, "{0:X2}", B);
+
+			return sb.ToString();
+		}
 
 		public static bool operator ==(Color color1, Color color2) => color1.Equals(color2);
 


### PR DESCRIPTION
GitHub Issue (If applicable): #5189

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?
Color.ToString() returns in format '[#AABBCCDD]' which is incorrect.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
Color.ToString() now returns in format '#AABBCCDD'.
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.